### PR TITLE
Improved Usability In Other Repos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ else()
 endif()
 
 add_subdirectory(src/logic)
+target_include_directories(game_engine PUBLIC src/maps)
 
 enable_testing()
 add_subdirectory(test)

--- a/src/logic/CMakeLists.txt
+++ b/src/logic/CMakeLists.txt
@@ -2,7 +2,7 @@ SET(Boost_USE_STATIC_LIBS        ON)
 set(Boost_USE_MULTITHREADED      ON)
 set(Boost_USE_STATIC_RUNTIME    OFF)
 
-add_subdirectory(${CMAKE_SOURCE_DIR}/lib/boost bin EXCLUDE_FROM_ALL)
+add_subdirectory(${PROJECT_SOURCE_DIR}/lib/boost bin EXCLUDE_FROM_ALL)
 
 add_library(game_engine STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/entity.cc 
@@ -15,6 +15,6 @@ add_library(game_engine STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/team.cc
 )
 
-target_link_libraries(game_engine PUBLIC Boost::serialization)
+target_link_libraries(game_engine PRIVATE Boost::serialization)
 target_include_directories(game_engine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,9 +16,12 @@ add_executable(entity_test entity_test.cc)
 
 target_link_libraries(
   entity_test 
+  PUBLIC
   game_engine
   gtest_main
 )
+
+target_link_libraries(entity_test PRIVATE Boost::serialization)
 
 gtest_discover_tests(entity_test)
 
@@ -34,6 +37,9 @@ target_link_libraries(
     game_engine
     gtest_main
 )
+
+target_link_libraries(map_test PRIVATE Boost::serialization)
+
 
 gtest_discover_tests(map_test)
 
@@ -51,6 +57,9 @@ target_link_libraries(
     gtest_main
 )
 
+target_link_libraries(mockcontroller_test PRIVATE Boost::serialization)
+
+
 gtest_discover_tests(mockcontroller_test)
 
 #Player Test
@@ -65,6 +74,10 @@ target_link_libraries(
     game_engine
     gtest_main
 )
+
+target_link_libraries(player_test PRIVATE Boost::serialization)
+
+
 gtest_discover_tests(player_test)
 
 #Projectile Launcher Test
@@ -79,6 +92,8 @@ target_link_libraries(
     game_engine
     gtest_main
 )
+
+target_link_libraries(projectilelauncher_test PRIVATE Boost::serialization)
 
 gtest_discover_tests(projectilelauncher_test)
 
@@ -95,6 +110,8 @@ target_link_libraries(
     gtest_main
 )
 
+target_link_libraries(team_test PRIVATE Boost::serialization)
+
 gtest_discover_tests(team_test)
 
 #ShooterWorld Test
@@ -110,5 +127,6 @@ target_link_libraries(
     gtest_main
 )
 
+target_link_libraries(shooterworld_test PRIVATE Boost::serialization)
 
 gtest_discover_tests(shooterworld_test)


### PR DESCRIPTION
Updated CMakeLists files to prevent boost from causing compile commands in other projects from exceeding 8,192 characters, and updated the project so that the example map header files are included in the engine.